### PR TITLE
change "previous meetings" to "history"

### DIFF
--- a/history.html
+++ b/history.html
@@ -6,7 +6,7 @@
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
-    <li class="nav-first-row"><a href="./previous-meetings.html">Previous Meetings</a></li>
+    <li class="nav-first-row"><a href="./history.html">History</a></li>
   </nav>
 </header>
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
-    <li class="nav-first-row"><a href="./previous-meetings.html">Previous Meetings</a></li>
+    <li class="nav-first-row"><a href="./history.html">History</a></li>
   </nav>
 </header>
 

--- a/pnwplse-2016.html
+++ b/pnwplse-2016.html
@@ -11,7 +11,7 @@
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
-    <li class="nav-first-row"><a href="./previous-meetings.html">Previous Meetings</a></li>
+    <li class="nav-first-row"><a href="./history.html">History</a></li>
   </nav>
 </header>
 

--- a/pnwplse-2018.html
+++ b/pnwplse-2018.html
@@ -11,7 +11,7 @@
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
-    <li class="nav-first-row"><a href="./previous-meetings.html">Previous Meetings</a></li>
+    <li class="nav-first-row"><a href="./history.html">History</a></li>
   </nav>
 </header>
 

--- a/pnwplse-2023.html
+++ b/pnwplse-2023.html
@@ -11,7 +11,7 @@
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
-    <li class="nav-first-row"><a href="./previous-meetings.html">Previous Meetings</a></li>
+    <li class="nav-first-row"><a href="./history.html">History</a></li>
   </nav>
 </header>
 


### PR DESCRIPTION
Small tweak so that the top of page links don't have line breaks.