### PR TITLE
Addressing all WAVE errors (and some warnings)

### DIFF
--- a/history.html
+++ b/history.html
@@ -1,8 +1,8 @@
+<html lang="en">
+<title>PNW PLSE History</title>
 <header>
   <link rel="stylesheet" href="./style.css">
-  <a href="./index.html">
-    <h1>PNW PLSE</h1>
-  </a>
+  <img src="./logo/header@2x.png"/ alt="PNW PLSE logo" width="225px" height="72px">
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
@@ -11,7 +11,7 @@
 </header>
 
 <section id="Previous Meetings">
-  <h3>Previous Meetings</h3>
+  <h1>Previous Meetings</h1>
   <ul>
     <li><a href="./pnwplse-2025.html">2025</a></li>
     <li><a href="./pnwplse-2024.html">2024</a></li>
@@ -20,4 +20,4 @@
     <li><a href="./pnwplse-2016.html">2016</a></li>
   </ul>
 </section>
-
+<html/>

--- a/index.html
+++ b/index.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
 <title>PNW PLSE 2025</title>
 </head>
 
 <header>
   <link rel="stylesheet" href="./style.css">
-  <a href="./index.html">
   <img src="./logo/header@2x.png"/ alt="PNW PLSE homepage" width="225px" height="72px">
-  </a>
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
@@ -39,4 +38,4 @@
   </p>
 </section>
 </body>
-
+</html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 
 <header>
   <link rel="stylesheet" href="./style.css">
-  <img src="./logo/header@2x.png"/ alt="PNW PLSE homepage" width="225px" height="72px">
+  <img src="./logo/header@2x.png"/ alt="PNW PLSE logo" width="225px" height="72px">
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>

--- a/pnwplse-2016.html
+++ b/pnwplse-2016.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
 <title>PNW PLSE 2016</title>
 </head>
 
 <header>
   <link rel="stylesheet" href="./style.css">
-  <a href="./index.html">
-    <h1>PNW PLSE</h1>
-  </a>
+  <img src="./logo/header@2x.png"/ alt="PNW PLSE logo" width="225px" height="72px">
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
@@ -17,16 +16,16 @@
 
 <body>
 <section id="PNW PLSE 2016">
-  <h3>PNW PLSE 2016</h3>
+  <h1>PNW PLSE 2016</h1>
   <p>
   The 2016 edition of PNW PLSE took place on Tuesday, March 15 at the Paul G.
   Allen Center for Computer Science &amp; Engineering!</p> 
 </section>
 
 <section id="PNW PLSE 2016 Schedule">
-  <h3>Schedule</h3>
+  <h2>Schedule</h2>
 
-  <h4>Session 1: Tools and Synthesis (Chair: Rishabh Singh)</h4>
+  <h3>Session 1: Tools and Synthesis (Chair: Rishabh Singh)</h3>
   12:00 - 14:30
   <ul style="list-style-type:none;">
     <li style="margin: 10px"><i>Data Structure Synthesis</i> (<a href="https://www.google.com/url?q=https%3A%2F%2Fhomes.cs.washington.edu%2F~akcheung%2Fpnw16%2Floncaric.pdf&sa=D&sntz=1&usg=AOvVaw3qo7YR8wr_5_NJcx1wQYyT">Slides</a>)
@@ -56,7 +55,7 @@
     </li>
   </ul>
 
-  <h4>Session 2: New Languages (Chair: Emina Torlak)</h4>
+  <h3>Session 2: New Languages (Chair: Emina Torlak)</h3>
   14:30 - 16:20
   <ul style="list-style-type:none;">
     <li style="margin: 10px"><i>Teaching with Grace in Introductory Programming Courses</i> (<a href="https://www.google.com/url?q=https%3A%2F%2Fhomes.cs.washington.edu%2F~akcheung%2Fpnw16%2Fblack.pdf&sa=D&sntz=1&usg=AOvVaw2gHFJ6i15kVD_sODnUk6wR">Slides</a>)
@@ -81,7 +80,7 @@
     </li>
   </ul>
 
-  <h4>Session 3: Analysis and Formal Methods (Chair: Ben Zorn)</h4>
+  <h3>Session 3: Analysis and Formal Methods (Chair: Ben Zorn)</h3>
   16:20 - 18:00
   <ul style="list-style-type:none;">
     <li style="margin: 10px"><i>Differential Program Verification: Leveraging and Extending Program Verification for Reasoning about Program Differences</i> (<a href="https://www.google.com/url?q=https%3A%2F%2Fhomes.cs.washington.edu%2F~akcheung%2Fpnw16%2Flahiri.pdf&sa=D&sntz=1&usg=AOvVaw0xsTXIzTSuuNYLwKjLiWiE">Slides</a>)
@@ -106,7 +105,7 @@
     </li>
   </ul>
 
-  <h4>Lightning Talks (Chair: Zach Tatlock)</h4>
+  <h3>Lightning Talks (Chair: Zach Tatlock)</h3>
   18:00 - 19:00
   <ul style="list-style-type:none;">
     <li style="margin: 10px"><i>Semantic Software Adaptation Using Verified Lifting</i> (<a href="https://www.google.com/url?q=https%3A%2F%2Fhomes.cs.washington.edu%2F~akcheung%2Fpnw16%2Fcheung.pdf&sa=D&sntz=1&usg=AOvVaw1QQ6jG-206c_-myBxE46vV">Slides</a>)
@@ -143,3 +142,4 @@
 
 </section>
 </body>
+<html>

--- a/pnwplse-2018.html
+++ b/pnwplse-2018.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
 <title>PNW PLSE 2018</title>
 </head>
 
 <header>
   <link rel="stylesheet" href="./style.css">
-  <a href="./index.html">
-    <h1>PNW PLSE</h1>
-  </a>
+  <img src="./logo/header@2x.png"/ alt="PNW PLSE logo" width="225px" height="72px">
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
@@ -17,7 +16,7 @@
 
 <body>
 <section id="PNW PLSE 2023">
-  <h3>PNW PLSE 2018</h3>
+  <h1>PNW PLSE 2018</h1>
   <p>
   The 2018 edition of PNW PLSE took place at MSR Building 99 at the Microsoft
   Research Campus, on Tuesday May 14, 2018.
@@ -25,9 +24,9 @@
 </section>
 
 <section id="PNW PLSE 2018 Schedule">
-  <h3>Schedule</h3>
+  <h2>Schedule</h2>
 
-  <h4>Session 1 (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2018/05/41246.compressed.pdf">Slides</a>)</h4>
+  <h3>Session 1 (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2018/05/41246.compressed.pdf">Slides (pdf)</a>)</h3>
   Welcome and introductions from Ben Zorn, Tom Ball, and Zach Tatlock.
   <ul style="list-style-type:none;">
     <li style="margin: 10px"><i>Concerto: Towards a Framework for Combined Concrete and Abstract Interpretation</i> (<a href="https://youtu.be/HJtvzyaGgGQ?t=149">Recording</a>)
@@ -52,7 +51,7 @@
     </li>
   </ul>
 
-  <h4>Session 2 (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2018/05/41247-ilovepdf-compressed.pdf">Slides</a>)</h4>
+  <h3>Session 2 (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2018/05/41247-ilovepdf-compressed.pdf">Slides (pdf)</a>)</h3>
   <ul style="list-style-type:none;">
     <li style="margin: 10px"><i>Helping Designers Explore the Space of Layout Variations with Constraints</i> (<a href="https://youtu.be/nWoLsMr_av8?t=18">Recording</a>)
       <ul style="list-style-type:none;">
@@ -81,7 +80,7 @@
     </li>
   </ul>
 
-  <h4>Session 3 (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2018/06/41248.compressed.pdf">Slides</a>)</h4>
+  <h3>Session 3 (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2018/06/41248.compressed.pdf">Slides (pdf)</a>)</h3>
   <ul style="list-style-type:none;">
     <li style="margin: 10px"><i>Project Everest: Theory Meets Reality</i> (<a href="https://www.youtube.com/watch?v=inJaA859m-Q">Recording</a>)
       <ul style="list-style-type:none;">
@@ -90,7 +89,7 @@
     </li>
   </ul>
 
-  <h4>Session 4 (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2018/05/41249.compressed.pdf">Slides</a>)</h4>
+  <h3>Session 4 (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2018/05/41249.compressed.pdf">Slides (pdf)</a>)</h3>
   <ul style="list-style-type:none;">
     <li style="margin: 10px"><i>Continuously Integrated Verified Cryptography</i> (<a href="https://www.youtube.com/watch?v=7cbITvLUp7o">Recording</a>)
       <ul style="list-style-type:none;">
@@ -114,7 +113,7 @@
     </li>
   </ul>
 
-  <h4>Session 5 (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2018/07/5b43a5157a95b-5b43a5157a95dPNW-PLSE-Workshop-Featured-Talk-Why-Not-Both-Applications-of-Variational-Programming-Chapel-Comes-of-Age-Productive-Parallelism-at-Scale-slides.pdf.pdf">Slides</a>)</h4>
+  <h3>Session 5 (<a href="https://www.microsoft.com/en-us/research/uploads/prod/2018/07/5b43a5157a95b-5b43a5157a95dPNW-PLSE-Workshop-Featured-Talk-Why-Not-Both-Applications-of-Variational-Programming-Chapel-Comes-of-Age-Productive-Parallelism-at-Scale-slides.pdf.pdf">Slides (pdf)</a>)</h3>
   <ul style="list-style-type:none;">
     <li style="margin: 10px"><i>Why Not Both? Applications of Variational Programming</i> (<a href="https://www.youtube.com/watch?v=xOOZi2MexRk">Recording</a>)
       <ul style="list-style-type:none;">
@@ -135,3 +134,4 @@
 
 </section>
 </body>
+<html>

--- a/pnwplse-2023.html
+++ b/pnwplse-2023.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
+<html lang="en">
+
 <head>
 <title>PNW PLSE 2023</title>
 </head>
 
 <header>
   <link rel="stylesheet" href="./style.css">
-  <a href="./index.html">
-    <h1>PNW PLSE</h1>
-  </a>
+  <img src="./logo/header@2x.png"/ alt="PNW PLSE logo" width="225px" height="72px">
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
@@ -58,7 +58,7 @@
 
   <h4>10:30 - Talks</h4>
   <ul style="list-style-type:none;">
-    <li style="margin: 10px"><i>Parallel Programming with Chapel</i> (<a href="./slides/2023/Brad Chamberlain.pdf">Slides</a> | <a href="https://drive.google.com/file/d/1xJBGwwYtNBXeUrx4xNF6utIIBlKj6ASx/view?usp=share_link">Recording</a>)
+    <li style="margin: 10px"><i>Parallel Programming with Chapel</i> (<a href="./slides/2023/Brad Chamberlain.pdf">Slides (pdf)</a> | <a href="https://drive.google.com/file/d/1xJBGwwYtNBXeUrx4xNF6utIIBlKj6ASx/view?usp=share_link">Recording</a>)
       <ul style="list-style-type:none;">
         <li>Brad Chamberlain, Hewlett Packard Enterprise</li>
       </ul>
@@ -68,7 +68,7 @@
         <li>Elliott Zackrone, University of Washington</li>
       </ul>
     </li>
-    <li style="margin: 10px"><i>Linear Types for Systems Verification</i> (<a href="./slides/2023/Jialin Li.pdf">Slides</a>)
+    <li style="margin: 10px"><i>Linear Types for Systems Verification</i> (<a href="./slides/2023/Jialin Li.pdf">Slides (pdf)</a>)
       <ul style="list-style-type:none;">
         <li>Jialin Li, University of Washington</li>
       </ul>
@@ -125,7 +125,7 @@
 
   <h4>13:30 - Lightning Talks</h4>
   <ul style="list-style-type:none;">
-    <li style="margin: 10px"><i>Analysis and Synthesis of Musical Counterpoint</i> (<a href="./slides/2023/John Leo.pdf">Slides</a>)
+    <li style="margin: 10px"><i>Analysis and Synthesis of Musical Counterpoint</i> (<a href="./slides/2023/John Leo.pdf">Slides (pdf)</a>)
       <ul style="list-style-type:none;">
         <li>John Leo, Halfaya Research</li>
       </ul>
@@ -140,12 +140,12 @@
         <li>Caroline Lemieux, University of British Columbia</li>
       </ul>
     </li>
-    <li style="margin: 10px"><i>Automated Type Inference in Python</i> (<a href="./slides/2023/Jifeng Wu.pdf">Slides</a> | <a href="https://drive.google.com/file/d/1i54NMwRgqbCv8KPU6Zfpk0KxYL-budiX/view?usp=share_link">Recording</a>)
+    <li style="margin: 10px"><i>Automated Type Inference in Python</i> (<a href="./slides/2023/Jifeng Wu.pdf">Slides (pdf)</a> | <a href="https://drive.google.com/file/d/1i54NMwRgqbCv8KPU6Zfpk0KxYL-budiX/view?usp=share_link">Recording</a>)
       <ul style="list-style-type:none;">
         <li>Jifeng Wu, University of British Columbia</li>
       </ul>
     </li>
-    <li style="margin:10px"><i>Lakeroad: Hardware Compilation via Program Synthesis</i> (<a href="./slides/2023/Gus Smith.pdf">Slides</a> | <a href="https://drive.google.com/file/d/165w2NcaRdSk_gy80TkHSQDb1z3yLnxyZ/view?usp=share_link">Recording</a>)
+    <li style="margin:10px"><i>Lakeroad: Hardware Compilation via Program Synthesis</i> (<a href="./slides/2023/Gus Smith.pdf">Slides (pdf)</a> | <a href="https://drive.google.com/file/d/165w2NcaRdSk_gy80TkHSQDb1z3yLnxyZ/view?usp=share_link">Recording</a>)
       <ul style="list-style-type:none;">
         <li>Gus Smith , University of Washington</li>
       </ul>
@@ -160,7 +160,7 @@
         <li>Daan Leijen, Microsoft Research</li>
       </ul>
     </li>
-    <li style="margin: 10px"><i>Programming Abstractions for Quantum Computing</i> (<a href="./slides/2023/Jennifer Paykin.pdf">Slides</a> | <a href="https://drive.google.com/file/d/1WAsXqQZMyNx2Vckvkp2d4xSNd_5oZ4jN/view?usp=share_link">Recording</a>)
+    <li style="margin: 10px"><i>Programming Abstractions for Quantum Computing</i> (<a href="./slides/2023/Jennifer Paykin.pdf">Slides (pdf)</a> | <a href="https://drive.google.com/file/d/1WAsXqQZMyNx2Vckvkp2d4xSNd_5oZ4jN/view?usp=share_link">Recording</a>)
       <ul style="list-style-type:none;">
         <li>Jennifer Paykin, Intel</li>
       </ul>
@@ -185,7 +185,7 @@
         <li>Adam Geller, University of British Columbia</li>
       </ul>
     </li>
-    <li style="margin:10px"><i>Checked C</i> (<a href="./slides/2023/David Tarditi.pdf">Slides</a> | <a href="https://drive.google.com/file/d/1e8T4sz96FRtYDzqdxMM2AFEf7Cfutn7z/view?usp=share_link">Recording</a>)
+    <li style="margin:10px"><i>Checked C</i> (<a href="./slides/2023/David Tarditi.pdf">Slides (pdf)</a> | <a href="https://drive.google.com/file/d/1e8T4sz96FRtYDzqdxMM2AFEf7Cfutn7z/view?usp=share_link">Recording</a>)
       <ul style="list-style-type:none;">
         <li>David Tarditi, Secure Software Development Project</li>
       </ul>
@@ -211,12 +211,12 @@
         <li>Josh Horowitz, University of Washington</li>
       </ul>
     </li>
-    <li style="margin: 10px"><i>Generating High-Performance Communication Kernels</i> (<a href="./slides/2023/Madan Musuvathi.pdf">Slides</a> | <a href="https://drive.google.com/file/d/1KAQq5RBVj8itJir7eyJ3opKL-4yayd1s/view?usp=share_link">Recording</a>)
+    <li style="margin: 10px"><i>Generating High-Performance Communication Kernels</i> (<a href="./slides/2023/Madan Musuvathi.pdf">Slides (pdf)</a> | <a href="https://drive.google.com/file/d/1KAQq5RBVj8itJir7eyJ3opKL-4yayd1s/view?usp=share_link">Recording</a>)
       <ul style="list-style-type:none;">
         <li>Madan Musuvathi, Microsoft Research</li>
       </ul>
     </li>
-    <li style="margin: 10px"><i>Generating Formally Verified Parsers with EverParse</i> (<a href="./slides/2023/Tahina Ramananandro.pdf">Slides</a> | <a href="https://drive.google.com/file/d/1NaoTweV_thK789pOCq2DTRbEn1wDD1Ld/view?usp=share_link">Recording</a>)
+    <li style="margin: 10px"><i>Generating Formally Verified Parsers with EverParse</i> (<a href="./slides/2023/Tahina Ramananandro.pdf">Slides (pdf)</a> | <a href="https://drive.google.com/file/d/1NaoTweV_thK789pOCq2DTRbEn1wDD1Ld/view?usp=share_link">Recording</a>)
       <ul style="list-style-type:none;">
         <li>Tahina Ramananandro, Microsoft Research</li>
       </ul>
@@ -239,3 +239,4 @@
 
 </section>
 </body>
+<html>

--- a/pnwplse-2024.html
+++ b/pnwplse-2024.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
 <title>PNW PLSE 2024</title>
 </head>
 
 <header>
   <link rel="stylesheet" href="./style.css">
-  <a href="./index.html">
-  <img src="./logo/header@2x.png"/ alt="PNW PLSE homepage" width="225px" height="72px">
-  </a>
+  <img src="./logo/header@2x.png"/ alt="PNW PLSE logo" width="225px" height="72px">
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
@@ -16,6 +15,7 @@
 </header>
 
 <body>
+<h1>PNW PLSE 2024</h1>
 <section>
   <p class="banner">
     If you're interested in getting involved with the next PNW PLSE, please
@@ -235,3 +235,4 @@
 </section>
 </body>
 
+<html>

--- a/pnwplse-2025.html
+++ b/pnwplse-2025.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
 <title>PNW PLSE 2025</title>
 </head>
 
 <header>
   <link rel="stylesheet" href="./style.css">
-  <a href="./index.html">
-  <img src="./logo/header@2x.png"/ alt="PNW PLSE homepage" width="225px" height="72px">
-  </a>
+  <img src="./logo/header@2x.png"/ alt="PNW PLSE logo" width="225px" height="72px">
   <nav>
     <li class="nav-first-row"><a href="./index.html">Home</a></li>
     <li class="nav-first-row"><a href="https://www.cs.washington.edu/visitors/getting_here">Travel</a></li>
@@ -16,6 +15,7 @@
 </header>
 
 <body>
+<h1>PNW PLSE 2025</h1>
 <section>
   <p class="banner">
     If you're interested in getting involved with the next PNW PLSE, please
@@ -160,3 +160,4 @@
 </section>
 </body>
 
+<html/>

--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ section { clear: left; padding: 0 0 0 }
 
 p, dd, blockquote {
     padding: 0; margin: 20px 0; line-height: 1.4;
-    text-rendering: optimizeLegibility; text-align: justify;
+    text-rendering: optimizeLegibility;
     hyphens: auto; -moz-hyphens: auto; -webkit-hyphens: auto;}
 }
 li p {


### PR DESCRIPTION
@mattxwang suggested suggested using the [WAVE accessibility toolkit](https://wave.webaim.org) for a first-pass over the PNW PLSE website.

This PR ensures that all the pages on the website are free from errors reported by WAVE.

However, there are still warnings related to making sure _linked_ PDFs and YouTube videos are accessible. I think that is beyond the scope of what we can do.